### PR TITLE
Add optional `directory` input to GitHub action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,13 +5,17 @@ branding:
   color: "purple"
 inputs:
   isMutating:
-    description: 'Modfiy Package.resolved in case of new versions'
+    description: 'Modify Package.resolved in case of new versions'
     required: false
     default: false
   failWhenOutdated:
     description: 'Action will fail if outdated dependencies were detected.'
     required: false
     default: true
+   directory:
+    description: 'The path to the directory where you want the swift commands to be run'
+    required: false
+    default: '.'
 outputs:
   outdatedDependencies:
     description: 'Boolean if any dependency is outdated'
@@ -23,3 +27,4 @@ runs:
   args:
     - ${{ inputs.isMutating }}
     - ${{ inputs.failWhenOutdated }}
+    - ${{ inputs.directory }}

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Action will fail if outdated dependencies were detected.'
     required: false
     default: true
-   directory:
+  directory:
     description: 'The path to the directory where you want the swift commands to be run'
     required: false
     default: '.'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 isMutating=$1
 failWhenOutdated=$2
+
+echo "Changing current directory..."
+cd $3
+
 echo "### Current Package Dependencies (swift package show-dependencies)"
 swift package show-dependencies
 SPU_RESULT=""


### PR DESCRIPTION
## Justification

I understand that this is not the most common use case, but some teams use a mono-repo where the `Package.swift` may not be at the root of the project. In my project, I have multiple directories containing multiple Swift Vapor servers. Unfortunately this GitHub action in its current form would not work as it was unable to run the Swift command from the root of the project.

## Changes

This pull request introduces a new input parameter called "directory". If provided, this will change the active directory to the path provided before running any further commands.

```yaml
    - name: Check Swift Package dependencies
      id: spm-dep-check
      uses: Sherlouk/swift-package-dependencies-check@main
      with:
         isMutating: true
         failWhenOutdated: false
         directory: 'Ingest'
```

It has been tested with the above snippet, it successfully found the "Ingest" directory. This is not a breaking change.

## Apology

I made all the code changes within GitHub's file editor which is not the great but is my excuse for the poor commits. Feel free to squash/rebase into a single commit.