### PR TITLE
Update to Swift 6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.9
+FROM swift:6.0
 
 ARG SWIFT_RELEASENOTES_REPOSITORY="https://github.com/SwiftPackageIndex/ReleaseNotes.git"
 ARG SWIFT_RELEASENOTES_BRANCH="main"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Internally the action utilizes `swift package show-dependencies` and `swift pack
 
 You can also pin to a [specific release](MarcoEidinger/swift-package-dependencies-check/releases) version in the format @2.x.x
 
+- Version 2.6.x is using Swift 6.0
 - Version 2.5.x is using Swift 5.9
 - Version 2.4.x is using Swift 5.8
 - Version 2.3.x is using Swift 5.7


### PR DESCRIPTION
You should be able to add the newest Swift 6.0 as Xcode 16 already uses Swift 6.
Let me know if I need to do anything else

Just add tag branch and create a tag for this version